### PR TITLE
Fixes issue #7 - confirmation dialogue for deleting sessions

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -93,15 +93,6 @@ function Main() {
     
     // State for delete confirmation dialog
     const [sessionToDelete, setSessionToDelete] = React.useState<Session | null>(null);
-    
-    // Debug: Log when dialog state changes (Milestone 3)
-    useEffect(() => {
-        if (sessionToDelete) {
-            console.log('[Milestone 3] Dialog opened for session:', sessionToDelete.name)
-        } else {
-            console.log('[Milestone 3] Dialog closed')
-        }
-    }, [sessionToDelete])
 
     const generateName = async (session: Session) => {
         client.replay(
@@ -159,21 +150,17 @@ function Main() {
 
     // Handlers for delete confirmation dialog
     const handleOpenDeleteDialog = (session: Session) => {
-        console.log('[Milestone 4] Delete button clicked - opening dialog for session:', session.name)
         setSessionToDelete(session)
     }
 
     const handleConfirmDelete = () => {
         if (sessionToDelete) {
-            console.log('[Milestone 2] Confirming deletion of session:', sessionToDelete.name)
             store.deleteChatSession(sessionToDelete)
             setSessionToDelete(null)
-            console.log('[Milestone 2] Session deleted successfully')
         }
     }
 
     const handleCancelDelete = () => {
-        console.log('[Milestone 2] Canceling delete dialog for session:', sessionToDelete?.name)
         setSessionToDelete(null)
     }
 
@@ -425,14 +412,8 @@ function Main() {
                 <DeleteConfirmationDialog
                     open={sessionToDelete !== null}
                     sessionName={sessionToDelete?.name || ''}
-                    onConfirm={() => {
-                        console.log('[Milestone 3] Delete button clicked in dialog')
-                        handleConfirmDelete()
-                    }}
-                    onCancel={() => {
-                        console.log('[Milestone 3] Cancel button clicked in dialog')
-                        handleCancelDelete()
-                    }}
+                    onConfirm={handleConfirmDelete}
+                    onCancel={handleCancelDelete}
                 />
                 {
                     store.toasts.map((toast) => (

--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -21,6 +21,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import * as prompts from './prompts'
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import CleanWidnow from './CleanWindow';
+import DeleteConfirmationDialog from './DeleteConfirmationDialog';
 import { ThemeSwitcherProvider } from './theme/ThemeSwitcher';
 
 const { useEffect, useState } = React
@@ -89,6 +90,18 @@ function Main() {
     const [configureChatConfig, setConfigureChatConfig] = React.useState<Session | null>(null);
 
     const [sessionClean, setSessionClean] = React.useState<Session | null>(null);
+    
+    // State for delete confirmation dialog
+    const [sessionToDelete, setSessionToDelete] = React.useState<Session | null>(null);
+    
+    // Debug: Log when dialog state changes (Milestone 3)
+    useEffect(() => {
+        if (sessionToDelete) {
+            console.log('[Milestone 3] Dialog opened for session:', sessionToDelete.name)
+        } else {
+            console.log('[Milestone 3] Dialog closed')
+        }
+    }, [sessionToDelete])
 
     const generateName = async (session: Session) => {
         client.replay(
@@ -143,6 +156,26 @@ function Main() {
     useEffect(() => {
         document.getElementById('message-input')?.focus() // better way?
     }, [messageInput])
+
+    // Handlers for delete confirmation dialog
+    const handleOpenDeleteDialog = (session: Session) => {
+        console.log('[Milestone 4] Delete button clicked - opening dialog for session:', session.name)
+        setSessionToDelete(session)
+    }
+
+    const handleConfirmDelete = () => {
+        if (sessionToDelete) {
+            console.log('[Milestone 2] Confirming deletion of session:', sessionToDelete.name)
+            store.deleteChatSession(sessionToDelete)
+            setSessionToDelete(null)
+            console.log('[Milestone 2] Session deleted successfully')
+        }
+    }
+
+    const handleCancelDelete = () => {
+        console.log('[Milestone 2] Canceling delete dialog for session:', sessionToDelete?.name)
+        setSessionToDelete(null)
+    }
 
     return (
         <Box sx={{
@@ -200,7 +233,7 @@ function Main() {
                                             store.switchCurrentSession(session)
                                             document.getElementById('message-input')?.focus() // better way?
                                         }}
-                                        deleteMe={() => store.deleteChatSession(session)}
+                                        deleteMe={() => handleOpenDeleteDialog(session)}
                                         copyMe={() => {
                                             const newSession = createSession(session.name + ' Copyed')
                                             newSession.messages = session.messages
@@ -389,6 +422,18 @@ function Main() {
                         />
                     )
                 }
+                <DeleteConfirmationDialog
+                    open={sessionToDelete !== null}
+                    sessionName={sessionToDelete?.name || ''}
+                    onConfirm={() => {
+                        console.log('[Milestone 3] Delete button clicked in dialog')
+                        handleConfirmDelete()
+                    }}
+                    onCancel={() => {
+                        console.log('[Milestone 3] Cancel button clicked in dialog')
+                        handleCancelDelete()
+                    }}
+                />
                 {
                     store.toasts.map((toast) => (
                         <Snackbar

--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -91,7 +91,6 @@ function Main() {
 
     const [sessionClean, setSessionClean] = React.useState<Session | null>(null);
     
-    // State for delete confirmation dialog
     const [sessionToDelete, setSessionToDelete] = React.useState<Session | null>(null);
 
     const generateName = async (session: Session) => {
@@ -148,7 +147,6 @@ function Main() {
         document.getElementById('message-input')?.focus() // better way?
     }, [messageInput])
 
-    // Handlers for delete confirmation dialog
     const handleOpenDeleteDialog = (session: Session) => {
         setSessionToDelete(session)
     }

--- a/src/devtools/DeleteConfirmationDialog.tsx
+++ b/src/devtools/DeleteConfirmationDialog.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './App.css';
+import {
+    Button, Dialog, DialogContent, DialogActions, DialogTitle, DialogContentText,
+} from '@mui/material';
+
+interface Props {
+    open: boolean
+    sessionName: string
+    onConfirm: () => void
+    onCancel: () => void
+}
+
+export default function DeleteConfirmationDialog(props: Props) {
+    return (
+        <Dialog open={props.open} onClose={props.onCancel}>
+            <DialogTitle>Delete Session</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    Are you sure you want to delete the session <strong>"{props.sessionName}"</strong>? 
+                    This action cannot be undone and all messages in this session will be permanently removed.
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={props.onCancel}>Cancel</Button>
+                <Button onClick={props.onConfirm} color="error">Delete</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+


### PR DESCRIPTION
This pull request adds a dialog for deletion of sessions.

Before: 
<img width="343" height="256" alt="image" src="https://github.com/user-attachments/assets/53a77518-9dc6-4ec4-85ec-08dbbea21b43" />
Delete button just deletes chat immediately

After:
<img width="994" height="267" alt="image" src="https://github.com/user-attachments/assets/d73e5521-5ea3-4b78-9a71-e7d34c147637" />
Dialog appears before deletion

Video Demo Link: https://youtu.be/3PfnvWxFshA

Fixes Issue #15 , Add confimation dialog for deleting sessions
