### PR TITLE
Fixes Issue #4 - [BUG] Deleting session session switch

### DIFF
--- a/src/devtools/SessionItem.tsx
+++ b/src/devtools/SessionItem.tsx
@@ -31,6 +31,9 @@ export default function SessionItem(props: Props) {
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+        // Prevent the click from bubbling up to the parent MenuItem which would
+        // trigger `switchMe()` (re-selecting the session) when opening the menu.
+        event.stopPropagation()
         event.preventDefault()
         setAnchorEl(event.currentTarget);
     };
@@ -63,7 +66,8 @@ export default function SessionItem(props: Props) {
                 open={open}
                 onClose={handleClose}
             >
-                <MenuItem key={session.id + 'edit'} onClick={() => {
+                <MenuItem key={session.id + 'edit'} onClick={(e: React.MouseEvent<HTMLElement>) => {
+                    e.stopPropagation()
                     editMe()
                     handleClose()
                 }} disableRipple>
@@ -71,7 +75,8 @@ export default function SessionItem(props: Props) {
                     Rename
                 </MenuItem>
 
-                <MenuItem key={session.id + 'copy'} onClick={() => {
+                <MenuItem key={session.id + 'copy'} onClick={(e: React.MouseEvent<HTMLElement>) => {
+                    e.stopPropagation()
                     copyMe()
                     handleClose()
                 }} disableRipple>
@@ -81,7 +86,8 @@ export default function SessionItem(props: Props) {
 
                 <Divider sx={{ my: 0.5 }} />
 
-                <MenuItem key={session.id + 'del'} onClick={() => {
+                <MenuItem key={session.id + 'del'} onClick={(e: React.MouseEvent<HTMLElement>) => {
+                    e.stopPropagation()
                     setAnchorEl(null)
                     handleClose()
                     deleteMe()

--- a/src/devtools/SessionItem.tsx
+++ b/src/devtools/SessionItem.tsx
@@ -31,8 +31,6 @@ export default function SessionItem(props: Props) {
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        // Prevent the click from bubbling up to the parent MenuItem which would
-        // trigger `switchMe()` (re-selecting the session) when opening the menu.
         event.stopPropagation()
         event.preventDefault()
         setAnchorEl(event.currentTarget);

--- a/src/devtools/store.ts
+++ b/src/devtools/store.ts
@@ -122,13 +122,25 @@ export default function useStore() {
     }
 
     const deleteChatSession = (target: Session) => {
+        // Find the index of the target BEFORE filtering because indices shift after removal
+        const targetIndex = chatSessions.findIndex((s) => s.id === target.id)
+
         const sessions = chatSessions.filter((s) => s.id !== target.id)
         if (sessions.length === 0) {
             sessions.push(createSession())
         }
+
         if (target.id === currentSession.id) {
-            switchCurrentSession(sessions[0])
+            // If there was a session before the deleted one, navigate to it.
+            // Otherwise (deleted was at index 0), navigate to the new index 0.
+            if (targetIndex > 0) {
+                const newIndex = Math.min(targetIndex - 1, sessions.length - 1)
+                switchCurrentSession(sessions[newIndex])
+            } else {
+                switchCurrentSession(sessions[0])
+            }
         }
+
         setSessions(sessions)
     }
     const updateChatSession = (session: Session) => {

--- a/src/devtools/store.ts
+++ b/src/devtools/store.ts
@@ -122,7 +122,6 @@ export default function useStore() {
     }
 
     const deleteChatSession = (target: Session) => {
-        // Find the index of the target BEFORE filtering because indices shift after removal
         const targetIndex = chatSessions.findIndex((s) => s.id === target.id)
 
         const sessions = chatSessions.filter((s) => s.id !== target.id)
@@ -131,8 +130,6 @@ export default function useStore() {
         }
 
         if (target.id === currentSession.id) {
-            // If there was a session before the deleted one, navigate to it.
-            // Otherwise (deleted was at index 0), navigate to the new index 0.
             if (targetIndex > 0) {
                 const newIndex = Math.min(targetIndex - 1, sessions.length - 1)
                 switchCurrentSession(sessions[newIndex])


### PR DESCRIPTION
This pull request alters the delete chat session logic so that the if a deleted session was active, the app navigates to the previous session. The index of the previous session is saved to do this.
<img width="328" height="411" alt="image" src="https://github.com/user-attachments/assets/063b7ace-7880-41f0-9605-db7e8902ca64" />
Now, if the session that you are on gets deleted, your view changes to the previous session. If you delete a different session, your view stays the same. 

Video Link: https://youtu.be/d1E7I4C5NE4