### PR TITLE
Add Real-Time Timer to Reasoning Blocks During AI Thinking

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -108,17 +108,36 @@ function Main() {
     }
 
     const generate = async (session: Session, promptMsgs: Message[], targetMsg: Message) => {
-        // mark message as reasoning & streaming and record start
         if (!targetMsg.metadata) targetMsg.metadata = {}
-        targetMsg.metadata.reasoning = true
-        targetMsg.metadata.streaming = true
-        // use performance.now for higher resolution; persistable timestamp (ms since epoch) not required here
-        const startMs = performance.now()
-        targetMsg.metadata._reasoningStart = startMs
-        store.updateChatSession(session)
 
-        // start shared timer (updates UI)
-        startTimerForId(targetMsg.id)
+        const preservedStart = typeof targetMsg.metadata._reasoningStart === 'number'
+            ? targetMsg.metadata._reasoningStart
+            : null
+        const startMs = preservedStart ?? performance.now()
+
+        const startIfNeeded = () => {
+            if (!targetMsg.metadata.streaming) {
+                targetMsg.metadata.reasoning = true
+                targetMsg.metadata.streaming = true
+                targetMsg.metadata._reasoningStart = startMs
+                store.updateChatSession(session)
+                startTimerForId(targetMsg.id)
+            }
+        }
+
+        const finalize = () => {
+            if (!targetMsg.metadata || !targetMsg.metadata.streaming && typeof targetMsg.metadata.reasoningTimerMs === 'number') return
+            const base = typeof targetMsg.metadata._reasoningStart === 'number' ? targetMsg.metadata._reasoningStart : startMs
+            const finalMs = Math.round(performance.now() - base)
+            targetMsg.metadata.reasoningTimerMs = finalMs
+            targetMsg.metadata.streaming = false
+            delete targetMsg.metadata._reasoningStart
+            setFinalTimerForId(targetMsg.id, finalMs)
+            stopTimerForId(targetMsg.id)
+            store.updateChatSession(session)
+        }
+
+        startIfNeeded()
 
         try {
             await client.replay(
@@ -128,10 +147,7 @@ function Main() {
                 (text) => {
                     for (let i = 0; i < session.messages.length; i++) {
                         if (session.messages[i].id === targetMsg.id) {
-                            session.messages[i] = {
-                                ...session.messages[i],
-                                content: text,
-                            }
+                            session.messages[i] = { ...session.messages[i], content: text }
                             break
                         }
                     }
@@ -139,7 +155,6 @@ function Main() {
                     setScrollToMsg({ msgId: targetMsg.id, smooth: false })
                 },
                 (err) => {
-                    // on error, record failure text and persist final duration
                     for (let i = 0; i < session.messages.length; i++) {
                         if (session.messages[i].id === targetMsg.id) {
                             session.messages[i] = {
@@ -149,35 +164,12 @@ function Main() {
                             break
                         }
                     }
-                    // compute final duration
-                    const finalMs = Math.round(performance.now() - startMs)
-                    targetMsg.metadata.reasoningTimerMs = finalMs
-                    targetMsg.metadata.streaming = false
-                    // notify timer manager
-                    setFinalTimerForId(targetMsg.id, finalMs)
-                    stopTimerForId(targetMsg.id)
-                    store.updateChatSession(session)
+                    finalize()
                 }
             )
-
-            // on success, compute final duration and persist
-            const finalMs = Math.round(performance.now() - startMs)
-            targetMsg.metadata.reasoningTimerMs = finalMs
-            targetMsg.metadata.streaming = false
-            setFinalTimerForId(targetMsg.id, finalMs)
-            stopTimerForId(targetMsg.id)
-            store.updateChatSession(session)
+            finalize()
         } catch (error) {
-            // replay throws after calling onError - we've already handled err in callback, but ensure metadata is consistent
-            if (!targetMsg.metadata) targetMsg.metadata = {}
-            if (typeof targetMsg.metadata._reasoningStart === 'number') {
-                const finalMs = Math.round(performance.now() - targetMsg.metadata._reasoningStart)
-                targetMsg.metadata.reasoningTimerMs = finalMs
-                setFinalTimerForId(targetMsg.id, finalMs)
-                stopTimerForId(targetMsg.id)
-            }
-            targetMsg.metadata.streaming = false
-            store.updateChatSession(session)
+            finalize()
         }
     }
 

--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -3,6 +3,7 @@ import './App.css';
 import Block from './Block'
 import * as client from './client'
 import SessionItem from './SessionItem'
+import { startTimerForId, setFinalTimerForId, stopTimerForId } from './hooks/useReasoningTimer'
 import {
     Toolbar, Box, Badge, Snackbar,
     List, ListSubheader, ListItemText, MenuList,
@@ -107,36 +108,77 @@ function Main() {
     }
 
     const generate = async (session: Session, promptMsgs: Message[], targetMsg: Message) => {
-        await client.replay(
-            store.settings.openaiKey,
-            store.settings.apiHost,
-            promptMsgs,
-            (text) => {
-                for (let i = 0; i < session.messages.length; i++) {
-                    if (session.messages[i].id === targetMsg.id) {
-                        session.messages[i] = {
-                            ...session.messages[i],
-                            content: text,
+        // mark message as reasoning & streaming and record start
+        if (!targetMsg.metadata) targetMsg.metadata = {}
+        targetMsg.metadata.reasoning = true
+        targetMsg.metadata.streaming = true
+        // use performance.now for higher resolution; persistable timestamp (ms since epoch) not required here
+        const startMs = performance.now()
+        targetMsg.metadata._reasoningStart = startMs
+        store.updateChatSession(session)
+
+        // start shared timer (updates UI)
+        startTimerForId(targetMsg.id)
+
+        try {
+            await client.replay(
+                store.settings.openaiKey,
+                store.settings.apiHost,
+                promptMsgs,
+                (text) => {
+                    for (let i = 0; i < session.messages.length; i++) {
+                        if (session.messages[i].id === targetMsg.id) {
+                            session.messages[i] = {
+                                ...session.messages[i],
+                                content: text,
+                            }
+                            break
                         }
-                        break
                     }
-                }
-                store.updateChatSession(session)
-                setScrollToMsg({ msgId: targetMsg.id, smooth: false })
-            },
-            (err) => {
-                for (let i = 0; i < session.messages.length; i++) {
-                    if (session.messages[i].id === targetMsg.id) {
-                        session.messages[i] = {
-                            ...session.messages[i],
-                            content: 'API Request Failed: \n```\n' + err.message + '\n```',
+                    store.updateChatSession(session)
+                    setScrollToMsg({ msgId: targetMsg.id, smooth: false })
+                },
+                (err) => {
+                    // on error, record failure text and persist final duration
+                    for (let i = 0; i < session.messages.length; i++) {
+                        if (session.messages[i].id === targetMsg.id) {
+                            session.messages[i] = {
+                                ...session.messages[i],
+                                content: 'API Request Failed: \n```\n' + err.message + '\n```',
+                            }
+                            break
                         }
-                        break
                     }
+                    // compute final duration
+                    const finalMs = Math.round(performance.now() - startMs)
+                    targetMsg.metadata.reasoningTimerMs = finalMs
+                    targetMsg.metadata.streaming = false
+                    // notify timer manager
+                    setFinalTimerForId(targetMsg.id, finalMs)
+                    stopTimerForId(targetMsg.id)
+                    store.updateChatSession(session)
                 }
-                store.updateChatSession(session)
+            )
+
+            // on success, compute final duration and persist
+            const finalMs = Math.round(performance.now() - startMs)
+            targetMsg.metadata.reasoningTimerMs = finalMs
+            targetMsg.metadata.streaming = false
+            setFinalTimerForId(targetMsg.id, finalMs)
+            stopTimerForId(targetMsg.id)
+            store.updateChatSession(session)
+        } catch (error) {
+            // replay throws after calling onError - we've already handled err in callback, but ensure metadata is consistent
+            if (!targetMsg.metadata) targetMsg.metadata = {}
+            if (typeof targetMsg.metadata._reasoningStart === 'number') {
+                const finalMs = Math.round(performance.now() - targetMsg.metadata._reasoningStart)
+                targetMsg.metadata.reasoningTimerMs = finalMs
+                setFinalTimerForId(targetMsg.id, finalMs)
+                stopTimerForId(targetMsg.id)
             }
-        )
+            targetMsg.metadata.streaming = false
+            store.updateChatSession(session)
+        }
     }
 
     const [ messageInput, setMessageInput ] = useState('')

--- a/src/devtools/Block.tsx
+++ b/src/devtools/Block.tsx
@@ -147,7 +147,6 @@ function _Block(props: Props) {
                                     {msg.role}
                                 </Typography>
                                 {
-                                    // Show timer for reasoning blocks (handles both streaming and completed states)
                                     msg.metadata && msg.metadata.reasoning && (
                                         <ReasoningTimerWrapper
                                             msgId={msg.id}
@@ -320,19 +319,15 @@ const ReasoningTimerWrapper = React.memo(function ReasoningTimerWrapper({
     msgId: string
     finalMs?: number | null
 }) {
-    // Just subscribe to the timer state - App.tsx manages start/stop
     const { running, elapsedMs } = useReasoningTimer(msgId)
 
-    // if there's a persisted final duration, show that
     if (typeof persistedFinalMs === 'number') {
         return <ElapsedDisplay finalMs={persistedFinalMs} />
     }
 
-    // show live elapsed when running
     if (running) {
         return <ElapsedDisplay running={running} elapsedMs={elapsedMs} finalMs={null} />
     }
 
-    // show nothing if not running and no final time
     return null
 })

--- a/src/devtools/Block.tsx
+++ b/src/devtools/Block.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useState, useRef ,useMemo } from 'react';
+import ElapsedDisplay from './ElapsedDisplay'
+import useReasoningTimer from './hooks/useReasoningTimer'
+import React from 'react'
 import { ChatCompletionRequestMessage, ChatCompletionRequestMessageRoleEnum } from './openai-node';
 import Box from '@mui/material/Box';
 import Avatar from '@mui/material/Avatar';
@@ -47,6 +50,11 @@ md.use(mila, { attrs: { target: "_blank", rel: "noopener" } })
 
 export type Message = ChatCompletionRequestMessage & {
     id: string
+    metadata?: {
+        reasoning?: boolean
+        reasoningTimerMs?: number | null
+        [key: string]: any
+    }
 }
 
 export interface Props {
@@ -134,9 +142,23 @@ function _Block(props: Props) {
                 <Grid item xs={11} sm container>
                     <Grid item xs container direction="column" spacing={2}>
                         <Grid item xs>
-                            <Typography variant="overline" component="div">
-                                {msg.role}
-                            </Typography>
+                            <div style={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography variant="overline" component="div">
+                                    {msg.role}
+                                </Typography>
+                                {
+                                    // If a final duration already exists, show it (static)
+                                    msg.metadata && typeof msg.metadata.reasoningTimerMs === 'number' && (
+                                        <ElapsedDisplay finalMs={msg.metadata.reasoningTimerMs} />
+                                    )
+                                }
+                                {
+                                    // If message is a reasoning block and streaming, show live timer via hook
+                                    msg.metadata && msg.metadata.reasoning && (
+                                        <ReasoningTimerWrapper msg={msg} />
+                                    )
+                                }
+                            </div>
                             {
                                 isEditing ? (
                                     <TextField
@@ -283,4 +305,27 @@ export default function Block(props: Props) {
     return useMemo(() => {
         return <_Block {...props} />
     }, [props.msg, props.showWordCount, props.showTokenCount])
+}
+
+function ReasoningTimerWrapper({ msg }: { msg: Message }) {
+    const { running, elapsedMs, finalMs, start, stop } = useReasoningTimer(msg.id)
+
+    // auto-start if the message has a streaming flag in metadata
+    React.useEffect(() => {
+        if (msg.metadata && msg.metadata.streaming) {
+            start()
+        }
+        return () => {
+            // do not persist final here; just stop updates
+            stop()
+        }
+    }, [msg.metadata && msg.metadata.streaming])
+
+    // if there's a persisted final duration, show that
+    if (msg.metadata && typeof msg.metadata.reasoningTimerMs === 'number') {
+        return <ElapsedDisplay finalMs={msg.metadata.reasoningTimerMs} />
+    }
+
+    // show live elapsed when running, otherwise show placeholder
+    return <ElapsedDisplay running={running} elapsedMs={elapsedMs} finalMs={null} />
 }

--- a/src/devtools/Block.tsx
+++ b/src/devtools/Block.tsx
@@ -147,15 +147,12 @@ function _Block(props: Props) {
                                     {msg.role}
                                 </Typography>
                                 {
-                                    // If a final duration already exists, show it (static)
-                                    msg.metadata && typeof msg.metadata.reasoningTimerMs === 'number' && (
-                                        <ElapsedDisplay finalMs={msg.metadata.reasoningTimerMs} />
-                                    )
-                                }
-                                {
-                                    // If message is a reasoning block and streaming, show live timer via hook
+                                    // Show timer for reasoning blocks (handles both streaming and completed states)
                                     msg.metadata && msg.metadata.reasoning && (
-                                        <ReasoningTimerWrapper msg={msg} />
+                                        <ReasoningTimerWrapper
+                                            msgId={msg.id}
+                                            finalMs={msg.metadata.reasoningTimerMs}
+                                        />
                                     )
                                 }
                             </div>
@@ -304,28 +301,38 @@ const StyledMenu = styled((props: MenuProps) => (
 export default function Block(props: Props) {
     return useMemo(() => {
         return <_Block {...props} />
-    }, [props.msg, props.showWordCount, props.showTokenCount])
+    }, [
+        props.msg.id,
+        props.msg.content,
+        props.msg.role,
+        props.msg.metadata?.reasoning,
+        props.msg.metadata?.streaming,
+        props.msg.metadata?.reasoningTimerMs,
+        props.showWordCount,
+        props.showTokenCount
+    ])
 }
 
-function ReasoningTimerWrapper({ msg }: { msg: Message }) {
-    const { running, elapsedMs, finalMs, start, stop } = useReasoningTimer(msg.id)
-
-    // auto-start if the message has a streaming flag in metadata
-    React.useEffect(() => {
-        if (msg.metadata && msg.metadata.streaming) {
-            start()
-        }
-        return () => {
-            // do not persist final here; just stop updates
-            stop()
-        }
-    }, [msg.metadata && msg.metadata.streaming])
+const ReasoningTimerWrapper = React.memo(function ReasoningTimerWrapper({
+    msgId,
+    finalMs: persistedFinalMs
+}: {
+    msgId: string
+    finalMs?: number | null
+}) {
+    // Just subscribe to the timer state - App.tsx manages start/stop
+    const { running, elapsedMs } = useReasoningTimer(msgId)
 
     // if there's a persisted final duration, show that
-    if (msg.metadata && typeof msg.metadata.reasoningTimerMs === 'number') {
-        return <ElapsedDisplay finalMs={msg.metadata.reasoningTimerMs} />
+    if (typeof persistedFinalMs === 'number') {
+        return <ElapsedDisplay finalMs={persistedFinalMs} />
     }
 
-    // show live elapsed when running, otherwise show placeholder
-    return <ElapsedDisplay running={running} elapsedMs={elapsedMs} finalMs={null} />
-}
+    // show live elapsed when running
+    if (running) {
+        return <ElapsedDisplay running={running} elapsedMs={elapsedMs} finalMs={null} />
+    }
+
+    // show nothing if not running and no final time
+    return null
+})

--- a/src/devtools/ElapsedDisplay.tsx
+++ b/src/devtools/ElapsedDisplay.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import Typography from '@mui/material/Typography'
 
 export interface ElapsedDisplayProps {
-    // If provided, displays final duration; otherwise shows live elapsed if provided
     finalMs?: number | null
     elapsedMs?: number
     running?: boolean
@@ -12,11 +11,9 @@ function formatDuration(ms: number): string {
     const totalSeconds = ms / 1000
 
     if (totalSeconds < 60) {
-        // For durations under 60 seconds, show decimal: "3.2s"
         return `${totalSeconds.toFixed(1)}s`
     }
 
-    // For durations 60 seconds or more, show minutes and seconds: "1m 23s"
     const minutes = Math.floor(totalSeconds / 60)
     const seconds = Math.floor(totalSeconds % 60)
     return `${minutes}m ${seconds}s`

--- a/src/devtools/ElapsedDisplay.tsx
+++ b/src/devtools/ElapsedDisplay.tsx
@@ -8,12 +8,26 @@ export interface ElapsedDisplayProps {
     running?: boolean
 }
 
+function formatDuration(ms: number): string {
+    const totalSeconds = ms / 1000
+
+    if (totalSeconds < 60) {
+        // For durations under 60 seconds, show decimal: "3.2s"
+        return `${totalSeconds.toFixed(1)}s`
+    }
+
+    // For durations 60 seconds or more, show minutes and seconds: "1m 23s"
+    const minutes = Math.floor(totalSeconds / 60)
+    const seconds = Math.floor(totalSeconds % 60)
+    return `${minutes}m ${seconds}s`
+}
+
 export default function ElapsedDisplay({ finalMs, elapsedMs = 0, running = false }: ElapsedDisplayProps) {
     let text: string
     if (finalMs != null) {
-        text = `⏱ ${(finalMs / 1000).toFixed(1)}s`
+        text = `⏱ ${formatDuration(finalMs)}`
     } else if (running) {
-        text = `⏱ ${(elapsedMs / 1000).toFixed(1)}s`
+        text = `⏱ ${formatDuration(elapsedMs)}`
     } else {
         text = '⏱ 0.0s'
     }

--- a/src/devtools/ElapsedDisplay.tsx
+++ b/src/devtools/ElapsedDisplay.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import Typography from '@mui/material/Typography'
+
+export interface ElapsedDisplayProps {
+    // If provided, displays final duration; otherwise shows live elapsed if provided
+    finalMs?: number | null
+    elapsedMs?: number
+    running?: boolean
+}
+
+export default function ElapsedDisplay({ finalMs, elapsedMs = 0, running = false }: ElapsedDisplayProps) {
+    let text: string
+    if (finalMs != null) {
+        text = `⏱ ${(finalMs / 1000).toFixed(1)}s`
+    } else if (running) {
+        text = `⏱ ${(elapsedMs / 1000).toFixed(1)}s`
+    } else {
+        text = '⏱ 0.0s'
+    }
+    return (
+        <Typography variant="caption" color="textSecondary" sx={{ ml: 1 }}>
+            {text}
+        </Typography>
+    )
+}

--- a/src/devtools/hooks/useReasoningTimer.tsx
+++ b/src/devtools/hooks/useReasoningTimer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useCallback } from 'react'
 
 type Subscriber = (state: { running: boolean; elapsedMs: number; finalMs: number | null }) => void
 
@@ -8,7 +8,7 @@ class TimerManager {
     interval?: number
     tickMs: number
 
-    constructor(tickMs = 300) {
+    constructor(tickMs = 100) {
         this.timers = new Map()
         this.subs = new Map()
         this.tickMs = tickMs
@@ -97,7 +97,7 @@ class TimerManager {
     }
 }
 
-const manager = new TimerManager(300)
+const manager = new TimerManager(100)
 
 // exported helpers for non-react contexts to control timers by id
 export function startTimerForId(messageId: string) {
@@ -130,18 +130,20 @@ export function useReasoningTimer(messageId?: string) {
         return unsub
     }, [messageId])
 
-    const start = () => {
+    const start = useCallback(() => {
         if (!messageId) return
         manager.start(messageId)
-    }
-    const stop = () => {
+    }, [messageId])
+
+    const stop = useCallback(() => {
         if (!messageId) return
         manager.stop(messageId)
-    }
-    const setFinal = (ms: number) => {
+    }, [messageId])
+
+    const setFinal = useCallback((ms: number) => {
         if (!messageId) return
         manager.setFinal(messageId, ms)
-    }
+    }, [messageId])
 
     return { running, elapsedMs, finalMs, start, stop, setFinal }
 }

--- a/src/devtools/hooks/useReasoningTimer.tsx
+++ b/src/devtools/hooks/useReasoningTimer.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState, useRef } from 'react'
+
+type Subscriber = (state: { running: boolean; elapsedMs: number; finalMs: number | null }) => void
+
+class TimerManager {
+    timers: Map<string, { startMs: number; elapsedMs: number; running: boolean; finalMs: number | null }>
+    subs: Map<string, Set<Subscriber>>
+    interval?: number
+    tickMs: number
+
+    constructor(tickMs = 300) {
+        this.timers = new Map()
+        this.subs = new Map()
+        this.tickMs = tickMs
+    }
+
+    ensureInterval() {
+        if (this.interval) return
+        this.interval = window.setInterval(() => this.tick(), this.tickMs)
+    }
+
+    clearIntervalIfIdle() {
+        const anyRunning = Array.from(this.timers.values()).some(t => t.running)
+        if (!anyRunning && this.interval) {
+            clearInterval(this.interval)
+            this.interval = undefined
+        }
+    }
+
+    tick() {
+        const now = performance.now()
+        for (const [id, t] of this.timers.entries()) {
+            if (t.running) {
+                t.elapsedMs = now - t.startMs
+                this.notify(id)
+            }
+        }
+        this.clearIntervalIfIdle()
+    }
+
+    notify(id: string) {
+        const s = this.subs.get(id)
+        const t = this.timers.get(id)
+        if (!s || !t) return
+        for (const cb of s) cb({ running: t.running, elapsedMs: t.elapsedMs, finalMs: t.finalMs })
+    }
+
+    start(id: string) {
+        const now = performance.now()
+        const existing = this.timers.get(id)
+        if (existing) {
+            existing.startMs = now - existing.elapsedMs
+            existing.running = true
+            existing.finalMs = null
+        } else {
+            this.timers.set(id, { startMs: now, elapsedMs: 0, running: true, finalMs: null })
+        }
+        this.ensureInterval()
+        this.notify(id)
+    }
+
+    stop(id: string) {
+        const t = this.timers.get(id)
+        if (!t) return
+        t.running = false
+        t.finalMs = t.elapsedMs
+        this.notify(id)
+        this.clearIntervalIfIdle()
+    }
+
+    setFinal(id: string, finalMs: number) {
+        const t = this.timers.get(id)
+        if (!t) {
+            this.timers.set(id, { startMs: performance.now() - finalMs, elapsedMs: finalMs, running: false, finalMs })
+        } else {
+            t.running = false
+            t.elapsedMs = finalMs
+            t.finalMs = finalMs
+        }
+        this.notify(id)
+    }
+
+    subscribe(id: string, cb: Subscriber) {
+        if (!this.subs.has(id)) this.subs.set(id, new Set())
+        this.subs.get(id)!.add(cb)
+        // ensure there is an entry
+        if (!this.timers.has(id)) {
+            this.timers.set(id, { startMs: performance.now(), elapsedMs: 0, running: false, finalMs: null })
+        }
+        // push initial state
+        const t = this.timers.get(id)!
+        cb({ running: t.running, elapsedMs: t.elapsedMs, finalMs: t.finalMs })
+        return () => {
+            this.subs.get(id)!.delete(cb)
+            if (this.subs.get(id)!.size === 0) this.subs.delete(id)
+        }
+    }
+}
+
+const manager = new TimerManager(300)
+
+// exported helpers for non-react contexts to control timers by id
+export function startTimerForId(messageId: string) {
+    manager.start(messageId)
+}
+export function stopTimerForId(messageId: string) {
+    manager.stop(messageId)
+}
+export function setFinalTimerForId(messageId: string, ms: number) {
+    manager.setFinal(messageId, ms)
+}
+
+export function useReasoningTimer(messageId?: string) {
+    const [running, setRunning] = useState(false)
+    const [elapsedMs, setElapsedMs] = useState(0)
+    const [finalMs, setFinalMs] = useState<number | null>(null)
+    const idRef = useRef(messageId)
+
+    useEffect(() => {
+        idRef.current = messageId
+    }, [messageId])
+
+    useEffect(() => {
+        if (!messageId) return
+        const unsub = manager.subscribe(messageId, (s) => {
+            setRunning(s.running)
+            setElapsedMs(Math.round(s.elapsedMs))
+            setFinalMs(s.finalMs)
+        })
+        return unsub
+    }, [messageId])
+
+    const start = () => {
+        if (!messageId) return
+        manager.start(messageId)
+    }
+    const stop = () => {
+        if (!messageId) return
+        manager.stop(messageId)
+    }
+    const setFinal = (ms: number) => {
+        if (!messageId) return
+        manager.setFinal(messageId, ms)
+    }
+
+    return { running, elapsedMs, finalMs, start, stop, setFinal }
+}
+
+export default useReasoningTimer

--- a/src/devtools/hooks/useReasoningTimer.tsx
+++ b/src/devtools/hooks/useReasoningTimer.tsx
@@ -83,11 +83,9 @@ class TimerManager {
     subscribe(id: string, cb: Subscriber) {
         if (!this.subs.has(id)) this.subs.set(id, new Set())
         this.subs.get(id)!.add(cb)
-        // ensure there is an entry
         if (!this.timers.has(id)) {
             this.timers.set(id, { startMs: performance.now(), elapsedMs: 0, running: false, finalMs: null })
         }
-        // push initial state
         const t = this.timers.get(id)!
         cb({ running: t.running, elapsedMs: t.elapsedMs, finalMs: t.finalMs })
         return () => {
@@ -99,7 +97,6 @@ class TimerManager {
 
 const manager = new TimerManager(100)
 
-// exported helpers for non-react contexts to control timers by id
 export function startTimerForId(messageId: string) {
     manager.start(messageId)
 }

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -4,6 +4,15 @@ import { ThemeMode } from './theme';
 
 export type Message = ChatCompletionRequestMessage & {
     id: string
+    // Optional metadata for UI features (reasoning timers, flags, etc.)
+    metadata?: {
+        // whether this message is a reasoning-type block (controls timer visibility)
+        reasoning?: boolean
+        // final persisted duration in milliseconds (optional)
+        reasoningTimerMs?: number | null
+        // allow other metadata fields
+        [key: string]: any
+    }
 }
 
 export interface Session{

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -4,13 +4,9 @@ import { ThemeMode } from './theme';
 
 export type Message = ChatCompletionRequestMessage & {
     id: string
-    // Optional metadata for UI features (reasoning timers, flags, etc.)
     metadata?: {
-        // whether this message is a reasoning-type block (controls timer visibility)
         reasoning?: boolean
-        // final persisted duration in milliseconds (optional)
         reasoningTimerMs?: number | null
-        // allow other metadata fields
         [key: string]: any
     }
 }


### PR DESCRIPTION
This PR adds a real-time timer that shows elapsed time during active thinking and final duration. This is for streaming responses. 

Before screenshot:
<img width="385" height="149" alt="image" src="https://github.com/user-attachments/assets/fc4ac444-c0ca-48bb-82da-7aba6480844f" />


After screenshot:
<img width="257" height="128" alt="image" src="https://github.com/user-attachments/assets/21357c71-4b20-47e7-bda5-197089df3b6a" />

Video link: https://youtu.be/Yjm8faevEM0

Fixes issue #18 