### PR TITLE
[FEATURE] Add Tooltips to Icon Buttons for Better User Experience

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -7,7 +7,7 @@ import {
     Toolbar, Box, Badge, Snackbar,
     List, ListSubheader, ListItemText, MenuList,
     IconButton, Button, Stack, Grid, MenuItem, ListItemIcon, Typography, Divider,
-    TextField,
+    TextField, Tooltip,
 } from '@mui/material';
 import { Session, createSession, Message, createMessage } from './types'
 import ChatIcon from '@mui/icons-material/Chat';
@@ -165,9 +165,11 @@ function Main() {
                         spacing={2}
                     >
                         <Toolbar variant="dense">
-                            <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
-                                <ChatIcon />
-                            </IconButton>
+                            <Tooltip title="ChatBox">
+                                <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+                                    <ChatIcon />
+                                </IconButton>
+                            </Tooltip>
                             <Typography variant="h5" color="inherit" component="div">
                                 ChatBox
                             </Typography>
@@ -216,7 +218,9 @@ function Main() {
 
                         <MenuItem onClick={() => store.createEmptyChatSession()} >
                             <ListItemIcon>
-                                <IconButton><AddIcon fontSize="small" /></IconButton>
+                                <Tooltip title="Create new chat">
+                                    <IconButton><AddIcon fontSize="small" /></IconButton>
+                                </Tooltip>
                             </ListItemIcon>
                             <ListItemText>
                                 New Chat
@@ -230,7 +234,9 @@ function Main() {
                         }}
                         >
                             <ListItemIcon>
-                                <IconButton><SettingsIcon fontSize="small" /></IconButton>
+                                <Tooltip title="Open settings">
+                                    <IconButton><SettingsIcon fontSize="small" /></IconButton>
+                                </Tooltip>
                             </ListItemIcon>
                             <ListItemText>
                                 Settings
@@ -245,9 +251,11 @@ function Main() {
                             openLink('https://github.com/Bin-Huang/chatbox/releases')
                         }}>
                             <ListItemIcon>
-                                <IconButton>
-                                    <InfoOutlinedIcon fontSize="small" />
-                                </IconButton>
+                                <Tooltip title="Check for updates">
+                                    <IconButton>
+                                        <InfoOutlinedIcon fontSize="small" />
+                                    </IconButton>
+                                </Tooltip>
                             </ListItemIcon>
                             <ListItemText>
                                 <Badge color="primary" variant="dot" invisible={!needCheckUpdate} sx={{ paddingRight: '8px' }} >
@@ -270,17 +278,21 @@ function Main() {
                         padding: '20px 0',
                     }} spacing={2}>
                         <Toolbar variant="dense">
-                            <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
-                                <ChatBubbleOutlineOutlinedIcon />
-                            </IconButton>
+                            <Tooltip title="Current conversation">
+                                <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+                                    <ChatBubbleOutlineOutlinedIcon />
+                                </IconButton>
+                            </Tooltip>
                             <Typography variant="h6" color="inherit" component="div" noWrap sx={{ flexGrow: 1 }}>
                                 {store.currentSession.name}
                             </Typography>
-                            <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}
-                                onClick={() => setSessionClean(store.currentSession)}
-                            >
-                                <CleaningServicesIcon />
-                            </IconButton>
+                            <Tooltip title="Clear all messages">
+                                <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}
+                                    onClick={() => setSessionClean(store.currentSession)}
+                                >
+                                    <CleaningServicesIcon />
+                                </IconButton>
+                            </Tooltip>
                         </Toolbar>
                         <Divider />
                         <List

--- a/src/devtools/Block.tsx
+++ b/src/devtools/Block.tsx
@@ -3,7 +3,7 @@ import { ChatCompletionRequestMessage, ChatCompletionRequestMessageRoleEnum } fr
 import Box from '@mui/material/Box';
 import Avatar from '@mui/material/Avatar';
 import MenuItem from '@mui/material/MenuItem';
-import { Button, Divider, ListItem, Typography, Grid, TextField, Menu, MenuProps } from '@mui/material';
+import { Button, Divider, ListItem, Typography, Grid, TextField, Menu, MenuProps, Tooltip } from '@mui/material';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import PersonIcon from '@mui/icons-material/Person';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
@@ -169,19 +169,25 @@ function _Block(props: Props) {
                         {
                             isEditing ? (
                                 <>
-                                <Button onClick={() => setIsEditing(false)}>
-                                    <CheckIcon fontSize='small' />
-                                </Button>
+                                <Tooltip title="Save changes">
+                                    <Button onClick={() => setIsEditing(false)}>
+                                        <CheckIcon fontSize='small' />
+                                    </Button>
+                                </Tooltip>
                                 </>
                             ) : (
                                 isHovering && (
                                     <>
-                                        <Button onClick={() => props.refreshMsg()}>
-                                            <RefreshIcon fontSize='small' />
-                                        </Button>
-                                        <Button onClick={handleClick}>
-                                            <MoreVertIcon />
-                                        </Button>
+                                        <Tooltip title="Regenerate response">
+                                            <Button onClick={() => props.refreshMsg()}>
+                                                <RefreshIcon fontSize='small' />
+                                            </Button>
+                                        </Tooltip>
+                                        <Tooltip title="More actions">
+                                            <Button onClick={handleClick}>
+                                                <MoreVertIcon />
+                                            </Button>
+                                        </Tooltip>
                                         <StyledMenu
                                             MenuListProps={{
                                                 'aria-labelledby': 'demo-customized-button',

--- a/src/devtools/SessionItem.tsx
+++ b/src/devtools/SessionItem.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import './App.css';
 import {
     ListItemText, ListItemAvatar, MenuItem, Divider,
-    Avatar, IconButton, Button, TextField, Popper, Fade, Typography, ListItemIcon,
+    Avatar, IconButton, Button, TextField, Popper, Fade, Typography, ListItemIcon, Tooltip,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Session } from './types'
@@ -45,16 +45,20 @@ export default function SessionItem(props: Props) {
             onClick={() => switchMe()}
         >
             <ListItemIcon>
-                <IconButton><ChatBubbleOutlineOutlinedIcon fontSize="small" /></IconButton>
+                <Tooltip title="Chat session">
+                    <IconButton><ChatBubbleOutlineOutlinedIcon fontSize="small" /></IconButton>
+                </Tooltip>
             </ListItemIcon>
             <ListItemText>
                 <Typography variant="inherit" noWrap>
                     {session.name}
                 </Typography>
             </ListItemText>
-            <IconButton onClick={handleClick}>
-                <MoreHorizOutlinedIcon />
-            </IconButton>
+            <Tooltip title="Session options">
+                <IconButton onClick={handleClick}>
+                    <MoreHorizOutlinedIcon />
+                </IconButton>
+            </Tooltip>
             <StyledMenu
                 MenuListProps={{
                     'aria-labelledby': 'long-button',


### PR DESCRIPTION
This pull request implements the use of tooltips when hovering over icons throughout the app in 11 places: 

1. Hover over the ChatBox logo icon and verify tooltip shows "ChatBox"
2. Hover over the settings gear icon and verify tooltip shows "Open settings"
3. Hover over the "+" icon and verify tooltip shows "Create new chat"
4. Hover over the info icon and verify tooltip shows "Check for updates"
5. In the message area, hover over the cleaning icon and verify tooltip shows "Clear all messages"
6. In the message area, hover over the chat bubble icon and verify tooltip shows "Current conversation"
8. Hover over the refresh icon and verify tooltip shows "Regenerate response"
9. Hover over the three-dot menu icon and verify tooltip shows "More actions"
10. While editing a message, hover over the checkmark and verify tooltip shows "Save changes"
11. In the session list, hover over the chat bubble icon and verify tooltip shows "Chat session"
12. In the session list, hover over the horizontal dots icon and verify tooltip shows "Session options"

Before screenshot:
<img width="68" height="70" alt="image" src="https://github.com/user-attachments/assets/004c3ba7-cb67-4768-99af-50b467880ec4" />

After screenshot:
<img width="81" height="89" alt="image" src="https://github.com/user-attachments/assets/f76cdbe1-9203-4eb3-bf21-35ab3f99ecdb" />

Video demo + code walkthrough: https://youtu.be/6M8RqNWGwrk

Fixes #34 
